### PR TITLE
Update to .NET 8

### DIFF
--- a/DisplayPluginLibrary/DisplayPluginLibrary.csproj
+++ b/DisplayPluginLibrary/DisplayPluginLibrary.csproj
@@ -8,7 +8,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />

--- a/DisplayPluginLibrary/DisplayPluginLibrary.csproj
+++ b/DisplayPluginLibrary/DisplayPluginLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call $(SolutionDir)scripts\deploy.bat $(TargetDir)$(ProjectName).dll" />
+  </Target>
 </Project>

--- a/DriverDisplayPlugin/DriverDisplayPlugin.csproj
+++ b/DriverDisplayPlugin/DriverDisplayPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -16,13 +16,13 @@
   <ItemGroup>
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/DriverDisplayPlugin/DriverDisplayPlugin.csproj
+++ b/DriverDisplayPlugin/DriverDisplayPlugin.csproj
@@ -14,7 +14,7 @@
     <Resource Include="Resources\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/DriverDisplayPlugin/Properties/AssemblyInfo.cs
+++ b/DriverDisplayPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("DriverDisplayPlugin")]
+[assembly: AssemblyDescription("Driver Display Plugin")]
+[assembly: Guid("8B7D58A4-A244-49D7-B2FF-45D697AA3C26")]
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
+++ b/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
@@ -8,7 +8,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
+++ b/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -8,7 +8,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.275-dev" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
@@ -18,11 +18,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
+++ b/EnhancedDisplayPlugin/EnhancedDisplayPlugin.csproj
@@ -8,7 +8,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.275-dev" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/EnhancedDisplayPlugin/Properties/AssemblyInfo.cs
+++ b/EnhancedDisplayPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("EnhancedDisplayPlugin")]
+[assembly: AssemblyDescription("Enhanced Display Plugin")]
+[assembly: Guid("8B7D58A4-A244-49D7-B2FF-45D697AA3C26")]
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/MAT.Atlas.Plugins.Samples.HelloConsole/MAT.Atlas.Plugins.Samples.HelloConsole.csproj
+++ b/MAT.Atlas.Plugins.Samples.HelloConsole/MAT.Atlas.Plugins.Samples.HelloConsole.csproj
@@ -11,7 +11,7 @@
     <Resource Include="Resources\Images\console.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/MAT.Atlas.Plugins.Samples.HelloConsole/MAT.Atlas.Plugins.Samples.HelloConsole.csproj
+++ b/MAT.Atlas.Plugins.Samples.HelloConsole/MAT.Atlas.Plugins.Samples.HelloConsole.csproj
@@ -1,22 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
-  <ItemGroup>
+	<ItemGroup>
     <Resource Include="Resources\Images\console.png" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/MAT.Atlas.Plugins.Samples.HelloWorld/MAT.Atlas.Plugins.Samples.HelloWorld.csproj
+++ b/MAT.Atlas.Plugins.Samples.HelloWorld/MAT.Atlas.Plugins.Samples.HelloWorld.csproj
@@ -11,7 +11,7 @@
     <Resource Include="Resources\Images\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />

--- a/MAT.Atlas.Plugins.Samples.HelloWorld/MAT.Atlas.Plugins.Samples.HelloWorld.csproj
+++ b/MAT.Atlas.Plugins.Samples.HelloWorld/MAT.Atlas.Plugins.Samples.HelloWorld.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -13,10 +13,12 @@
   <ItemGroup>
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <PropertyGroup />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/MAT.OCS.Atlas10.ClientAPI.sln
+++ b/MAT.OCS.Atlas10.ClientAPI.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30717.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36518.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MAT.Atlas.Plugins.Samples.HelloWorld", "MAT.Atlas.Plugins.Samples.HelloWorld\MAT.Atlas.Plugins.Samples.HelloWorld.csproj", "{731083C3-DDEA-4F94-82BE-BE20E9CAA299}"
 EndProject

--- a/NumericCompareDisplayPlugin/NumericCompareDisplayPlugin.csproj
+++ b/NumericCompareDisplayPlugin/NumericCompareDisplayPlugin.csproj
@@ -14,7 +14,7 @@
     <Resource Include="Resources\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />

--- a/NumericCompareDisplayPlugin/NumericCompareDisplayPlugin.csproj
+++ b/NumericCompareDisplayPlugin/NumericCompareDisplayPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -16,12 +16,12 @@
   <ItemGroup>
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/NumericCompareDisplayPlugin/Properties/AssemblyInfo.cs
+++ b/NumericCompareDisplayPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NumericCompareDisplayPlugin")]
+[assembly: AssemblyDescription("Numeric Compare Display Plugin")]
+[assembly: Guid("8B8E85EB-B20A-4EB4-959E-D05A2CE0AD95")]
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ ATLAS Display API is available as a Nuget package to registered users from the *
 
 See the [API Documentation](https://mat-docs.github.io/)
 
-## Atlas.DisplayAPI targetting .NET6 only from version 11.2.3.460 onwards
-Version 11.2.3.460 of Atlas.DisplayAPI will be the first release that only targets .NET6; we will no longer support .NET Framework integrations from this point onwards. If you still require .NET Framework compatiable builds then please use an older version from the Repository.
+## .NET 8 support from version TBC 
+Version TBC of `Atlas.DisplayAPI` will be the first release to officially support .NET 8. While plugins built for .NET 6 are expected to remain compatible, we recommend upgrading to .NET 8 to benefit from performance improvements, support, and enhanced features.
+
+## .NET 6 support from version 11.2.3.460
+Version 11.2.3.460 of `Atlas.DisplayAPI` will be the first release that only targets .NET 6; we will no longer support .NET Framework integrations from this point onwards. If you still require .NET Framework compatiable builds then please use an older version from the Repository.
 
 ## Notes on upgrading Atlas.DisplayAPI package from versions prior to 11.1.2.344
 
-Version 11.1.2.344 of Atlas.DisplayAPI upgrades System.Reactive from 3.1.1 to 4.4.1. If you are developing your solution in Visual Studio then be advised that the Nuget upgrade process does not automatically remove any previously dependent packages that are no longer required. 
+Version 11.1.2.344 of `Atlas.DisplayAPI` upgrades `System.Reactive` from `3.1.1` to `4.4.1`. If you are developing your solution in Visual Studio then be advised that the Nuget upgrade process does not automatically remove any previously dependent packages that are no longer required. 
 In order to reduce the likelihood of runtime errors we strongly recommend you manually remove the following redundant package following the upgrade:
 
-1. System.Reactive.Interfaces 3.1.1
+1. `System.Reactive.Interfaces` `3.1.1`

--- a/SampleDisplayPlugin/Properties/AssemblyInfo.cs
+++ b/SampleDisplayPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SampleDisplayPlugin")]
+[assembly: AssemblyDescription("Sample Display Plugin")]
+[assembly: Guid("8B7D58A4-A244-49D7-B2FF-45D697AA3C26")]
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/SampleDisplayPlugin/SampleDisplayPlugin.csproj
+++ b/SampleDisplayPlugin/SampleDisplayPlugin.csproj
@@ -8,7 +8,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>

--- a/SampleDisplayPlugin/SampleDisplayPlugin.csproj
+++ b/SampleDisplayPlugin/SampleDisplayPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -17,10 +17,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;" />
+  </Target>
 </Project>

--- a/SimpleGaugePlugin/Properties/AssemblyInfo.cs
+++ b/SimpleGaugePlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SimpleGaugePlugin")]
+[assembly: AssemblyDescription("Simple Gauge Plugin")]
+[assembly: Guid("8B8E85EB-B20A-4EB4-959E-D05A2CE0AD95")]
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/SimpleGaugePlugin/SimpleGaugePlugin.csproj
+++ b/SimpleGaugePlugin/SimpleGaugePlugin.csproj
@@ -15,7 +15,7 @@
     <Resource Include="Resources\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Atlas.DisplayAPI" Version="*" />
+    <PackageReference Include="Atlas.DisplayAPI" Version="11.4.4.349-W47" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="CircularGauge" Version="1.0.0" />
     <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />

--- a/SimpleGaugePlugin/SimpleGaugePlugin.csproj
+++ b/SimpleGaugePlugin/SimpleGaugePlugin.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DisplayPluginLibrary\DisplayPluginLibrary.csproj" />
@@ -17,13 +18,12 @@
     <PackageReference Include="Atlas.DisplayAPI" Version="*" />
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="CircularGauge" Version="1.0.0" />
-    <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
+    <PackageReference Include="MAT.OCS.Core" Version="2.3.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)$(ProjectName).dll"
-call "$(SolutionDir)scripts\deploy.bat" "$(TargetDir)CircularGauge.dll"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)$(TargetFileName)&quot;&#xD;&#xA;call &quot;$(SolutionDir)scripts\deploy.bat&quot; &quot;$(TargetDir)CircularGauge.dll&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Updated projects to `net8.0` from `net6.0`
- Fixed post build event which was not working to copy `.dll` to installed Atlas path.
- Added `AssemblyInfo.cs` to examples as they would not run in Atlas otherwise.